### PR TITLE
【Fixed】Step4

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,8 @@ gem 'net-smtp'
 gem 'net-imap'
 gem 'net-pop'
 gem 'kaminari'
+gem 'faker'
+gem 'bcrypt', '~> 3.1.7'
 
 group :development, :test do
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -62,6 +62,7 @@ GEM
       zeitwerk (~> 2.3)
     addressable (2.8.1)
       public_suffix (>= 2.0.2, < 6.0)
+    bcrypt (3.1.18)
     bindex (0.8.1)
     bootsnap (1.16.0)
       msgpack (~> 1.2)
@@ -86,6 +87,8 @@ GEM
     factory_bot_rails (6.2.0)
       factory_bot (~> 6.2.0)
       railties (>= 5.0.0)
+    faker (3.1.1)
+      i18n (>= 1.8.11, < 2)
     ffi (1.15.5)
     globalid (1.1.0)
       activesupport (>= 5.0)
@@ -257,10 +260,12 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  bcrypt (~> 3.1.7)
   bootsnap (>= 1.4.4)
   byebug
   capybara (>= 3.26)
   factory_bot_rails
+  faker
   jbuilder (~> 2.7)
   kaminari
   listen (~> 3.3)

--- a/app/assets/stylesheets/admin/users.scss
+++ b/app/assets/stylesheets/admin/users.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the Admin::Users controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: https://sass-lang.com/

--- a/app/assets/stylesheets/sessions.scss
+++ b/app/assets/stylesheets/sessions.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the sessions controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: https://sass-lang.com/

--- a/app/assets/stylesheets/users.scss
+++ b/app/assets/stylesheets/users.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the users controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: https://sass-lang.com/

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -2,7 +2,7 @@ class Admin::UsersController < ApplicationController
   before_action :set_user, only: %i[ edit update show destroy ]
 
   def index
-    @users = User.all
+    @users = User.all.includes(:tasks)
   end
 
   def new

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,0 +1,52 @@
+class Admin::UsersController < ApplicationController
+  before_action :set_user, only: %i[ edit update show destroy ]
+
+  def index
+    @users = User.all
+  end
+
+  def new
+    @user = User.new
+  end
+
+  def create
+    @user = User.new(user_params)
+    if @user.save
+      redirect_to admin_user_url(@user), notice: "ユーザー登録が完了しました"
+    else
+      render :new
+    end
+  end
+
+  def edit
+  end
+
+  def show
+  end
+
+  def update
+    if @user.update(user_params)
+      redirect_to admin_user_url(@user), notice: "ユーザー情報を更新しました"
+    else
+      render :edit
+    end
+  end
+
+  def destroy
+    if @user.destroy
+      redirect_to admin_user_url,notice: "削除しました"
+    else
+      render :edit
+    end
+  end
+
+  private
+  def set_user
+    @user = User.find(params[:id])
+  end
+
+  def user_params
+    params.require(:user).permit(:name, :email, :password,
+                              :password_confirmation, :admin)
+  end
+end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -34,7 +34,7 @@ class Admin::UsersController < ApplicationController
 
   def destroy
     if @user.destroy
-      redirect_to admin_user_url,notice: "削除しました"
+      redirect_to admin_users_path,notice: "削除しました"
     else
       render :edit
     end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,5 +1,6 @@
 class Admin::UsersController < ApplicationController
   before_action :set_user, only: %i[ edit update show destroy ]
+  before_action :require_admin
 
   def index
     @users = User.all.includes(:tasks)
@@ -48,5 +49,11 @@ class Admin::UsersController < ApplicationController
   def user_params
     params.require(:user).permit(:name, :email, :password,
                               :password_confirmation, :admin)
+  end
+
+  def require_admin
+    unless current_user.admin?
+      redirect_to root_path, notice: "管理者以外はアクセスできません"
+    end
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,8 @@
 class ApplicationController < ActionController::Base
   helper_method :current_user
   before_action :login_required
+  protect_from_forgery with: :exception
+  include SessionsHelper
 
   private
   def current_user

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,13 @@
 class ApplicationController < ActionController::Base
+  helper_method :current_user
+  before_action :login_required
+
+  private
+  def current_user
+    @current_user ||= User.find_by(id: session[:user_id]) if session[:user_id]
+  end
+
+  def login_required
+    redirect_to new_session_path unless current_user
+  end
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,0 +1,23 @@
+class SessionsController < ApplicationController
+  skip_before_action :login_required, only: [:new, :create]
+
+  def new
+  end
+
+  def create
+    user= User.find_by(email: params[:session][:email].downcase)
+		if user&& user.authenticate(params[:session][:password])
+			session[:user_id]= user.id
+      redirect_to root_url
+		else
+      flash.now[:danger]= 'ログインに失敗しました'
+      render :new
+		end
+	end
+
+  def destroy
+    session.delete(:user_id)
+    flash[:notice] = 'ログアウトしました'
+      redirect_to new_session_path
+  end
+end

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -2,6 +2,7 @@ class TasksController < ApplicationController
   before_action :set_task, only: %i[ show edit update destroy ]
 
   def index
+    @tasks = current_user.tasks.order(created_at: :desc)
     if params[:sort_limit]
       @tasks = Task.latest
       @tasks = @tasks.page(params[:page]).per(5)
@@ -25,7 +26,7 @@ class TasksController < ApplicationController
   end
 
   def create
-    @task = Task.new(task_params)
+    @task = current_user.tasks.new(task_params)
 
     respond_to do |format|
       if @task.save
@@ -52,7 +53,7 @@ class TasksController < ApplicationController
 
   def destroy
     @task.destroy
-
+    
     respond_to do |format|
       format.html { redirect_to tasks_url, notice: "Task was successfully destroyed." }
       format.json { head :no_content }

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -2,7 +2,7 @@ class TasksController < ApplicationController
   before_action :set_task, only: %i[ show edit update destroy ]
 
   def index
-    @tasks = current_user.tasks.order(created_at: :desc)
+    @tasks = current_user.tasks.order(created_at: :desc).page(params[:page]).per(5)
     if params[:sort_limit]
       @tasks = Task.latest
       @tasks = @tasks.page(params[:page]).per(5)
@@ -10,8 +10,9 @@ class TasksController < ApplicationController
       @tasks = Task.priority_sort
       @tasks = @tasks.page(params[:page]).per(5)
     else
-      @tasks = Task.all.order(created_at: :desc)
-      @tasks = @tasks.page(params[:page]).per(5)
+      # @tasks = Task.all.order(created_at: :desc)
+      # @tasks = @tasks.page(params[:page]).per(5)
+      @tasks = current_user.tasks.order(created_at: :desc).page(params[:page]).per(5)
     end
   end
 
@@ -66,7 +67,7 @@ class TasksController < ApplicationController
 
   private
     def set_task
-      @task = Task.find(params[:id])
+      @task = current_user.tasks.find(params[:id])
     end
 
     def task_params

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,0 +1,63 @@
+class UsersController < ApplicationController
+  skip_before_action :login_required, only: [:new, :create]
+  before_action :set_user, only: %i[ show edit update destroy ]
+
+  def index
+    @users = User.all
+  end
+
+  def new
+    @user = User.new
+  end
+
+  def create
+    @user = User.new(user_params)
+    if @user.save
+      session[:user_id] = @user.id
+      redirect_to user_path(@user.id)
+    else
+      render :new
+    end
+  end
+
+    def show
+      if current_user == User.find(params[:id])
+        @user = User.find(params[:id])
+      else
+        redirect_to tasks_path, notice: "権限がありません"
+      end
+    end
+  
+    def edit
+      if @user == current_user
+        render "edit"
+      else
+        redirect_to users_path
+      end
+    end
+  
+    def update
+      if @user.update(user_params)
+        redirect_to user_path, notice: "プロフィールを編集しました！"
+      else
+        flash.now[:danger] = "プロフィールを更新できませんでした"
+        render :edit
+      end
+    end
+
+    def destroy
+      @user.destroy
+      redirect_to users_url, notice: "ユーザーを削除しました"
+    end
+  
+    private
+
+    def set_user
+      @user = User.find(params[:id])
+    end
+  
+    def user_params
+      params.require(:user).permit(:name, :email, :password,
+                                  :password_confirmation,)
+    end
+end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -7,6 +7,7 @@ class UsersController < ApplicationController
   end
 
   def new
+    redirect_to user_path(current_user.id) if logged_in?
     @user = User.new
   end
 

--- a/app/helpers/admin/users_helper.rb
+++ b/app/helpers/admin/users_helper.rb
@@ -1,0 +1,2 @@
+module Admin::UsersHelper
+end

--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -1,0 +1,5 @@
+module SessionsHelper
+  def logged_in?
+    current_user.present?
+  end
+end

--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -1,4 +1,9 @@
 module SessionsHelper
+
+  def current_user
+    @current_user||= User.find_by(id: session[:user_id])
+	end
+  
   def logged_in?
     current_user.present?
   end

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -1,0 +1,2 @@
+module UsersHelper
+end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -1,4 +1,6 @@
 class Task < ApplicationRecord
+  belongs_to :user
+
   validates :title, presence: true, length: { maximum: 50}
   validates :content, presence: true,  length: { maximum: 200}
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,0 +1,2 @@
+class User < ApplicationRecord
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,2 +1,7 @@
 class User < ApplicationRecord
+  has_secure_password
+
+  validates :name,  presence: true, length: { maximum: 30 }
+  validates :email, presence: true, uniqueness: true, length: { maximum: 255 },
+                    format: { with: /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i }
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,4 +9,17 @@ class User < ApplicationRecord
   validates :password, length: { minimum: 6 }
 
   before_validation { email.downcase! }
+  before_destroy :validate_admin_user_existence
+
+  def admin?
+    self.admin == true
+  end
+
+  private
+  def validate_admin_user_existence
+    if admin? && User.where(admin: true).count <= 1
+      errors.add(:base, "管理者権限を持つユーザが必要です")
+      throw :abort
+    end
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,4 +4,7 @@ class User < ApplicationRecord
   validates :name,  presence: true, length: { maximum: 30 }
   validates :email, presence: true, uniqueness: true, length: { maximum: 255 },
                     format: { with: /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i }
+  validates :password, length: { minimum: 6 }
+  
+  before_validation { email.downcase! }
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,10 +1,12 @@
 class User < ApplicationRecord
+  has_many :tasks
+  
   has_secure_password
 
   validates :name,  presence: true, length: { maximum: 30 }
   validates :email, presence: true, uniqueness: true, length: { maximum: 255 },
                     format: { with: /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i }
   validates :password, length: { minimum: 6 }
-  
+
   before_validation { email.downcase! }
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,5 @@
 class User < ApplicationRecord
-  has_many :tasks
+  has_many :tasks, dependent: :destroy
   
   has_secure_password
 

--- a/app/views/admin/users/edit.html.erb
+++ b/app/views/admin/users/edit.html.erb
@@ -1,0 +1,2 @@
+<h1>Admin::Users#edit</h1>
+<p>Find me in app/views/admin/users/edit.html.erb</p>

--- a/app/views/admin/users/edit.html.erb
+++ b/app/views/admin/users/edit.html.erb
@@ -1,8 +1,8 @@
 <% if @user.errors.any? %>
     <div id="error_explanation">
-      <h2><%= pluralize(user.errors.count, "error") %> prohibited this user from being saved:</h2>
+      <h2><%= pluralize(@user.errors.count, "error") %> prohibited this user from being saved:</h2>
       <ul>
-        <% user.errors.each do |error| %>
+        <% @user.errors.each do |error| %>
           <li><%= error.full_message %></li>
         <% end %>
       </ul>

--- a/app/views/admin/users/edit.html.erb
+++ b/app/views/admin/users/edit.html.erb
@@ -1,2 +1,43 @@
-<h1>Admin::Users#edit</h1>
-<p>Find me in app/views/admin/users/edit.html.erb</p>
+<% if @user.errors.any? %>
+    <div id="error_explanation">
+      <h2><%= pluralize(user.errors.count, "error") %> prohibited this user from being saved:</h2>
+      <ul>
+        <% user.errors.each do |error| %>
+          <li><%= error.full_message %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+<h3>Edit</h3>
+<%= form_with(model: @user,url: admin_user_path, local: true) do |f| %>
+  <div class="field">
+    <%= f.label :name %>
+    <%= f.text_field :name %>
+  </div>
+
+  <div class="field">
+    <%= f.label :email %>
+    <%= f.email_field :email %>
+  </div>
+
+  <div class="field">
+    <%= f.label :password %>
+    <%= f.password_field :password %>
+  </div>
+
+  <div class="field">
+    <%= f.label :password_confirmation %>
+    <%= f.password_field :password_confirmation %>
+  </div>
+
+  <div class="field">
+    <%= f.label :administrator %>
+    <%= f.radio_button :admin, :true %>
+  </div>
+    
+  <div class="field">
+    <%= f.label :general%>
+    <%= f.radio_button :admin, :false %>
+  </div>
+    <div class = "btn"><%= f.submit "Update" %></div>
+<% end %>

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -8,9 +8,7 @@
         <th>ユーザー名</th>
         <th>メールアドレス</th>
         <th>管理権限</th>
-        <th></th>
-        <th></th>
-        <th></th>
+        <th>タスク数</th>
       </tr>
     </thead>
     <tbody>
@@ -18,8 +16,8 @@
         <tr class="">
           <td><%= user.name %></td>
           <td><%= user.email %></td>
-          
           <td><%= user.admin %></td>
+          <td><%= user.tasks.size %></td>
           <td><%= link_to '詳細', admin_user_path(user), class: "btn btn-outline-primary btn-sm", id: "user_detail"%></td>
           <td><%= link_to '編集', edit_admin_user_path(user), class: "btn btn-outline-success btn-sm", id: "user_edit" %></td>
           <td><%= link_to '削除', admin_user_path(user), method: :delete, data: { confirm: '削除してよろしいですか？' }, class: "btn btn-outline-danger btn-sm", id: "user_destroy" %></td>

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -1,0 +1,31 @@
+<div class="content">
+  <h1>ユーザー管理画面</h1>
+  <p id="notice"><%= notice %></p>
+  <%= link_to 'ユーザーを登録する', new_admin_user_path, id: "user_create" %>
+  <table class="table list">
+    <thead>
+      <tr>
+        <th>ユーザー名</th>
+        <th>メールアドレス</th>
+        <th>管理権限</th>
+        <th></th>
+        <th></th>
+        <th></th>
+      </tr>
+    </thead>
+    <tbody>
+      <% @users.each do |user| %>
+        <tr class="">
+          <td><%= user.name %></td>
+          <td><%= user.email %></td>
+          
+          <td><%= user.admin %></td>
+          <td><%= link_to '詳細', admin_user_path(user), class: "btn btn-outline-primary btn-sm", id: "user_detail"%></td>
+          <td><%= link_to '編集', edit_admin_user_path(user), class: "btn btn-outline-success btn-sm", id: "user_edit" %></td>
+          <td><%= link_to '削除', admin_user_path(user), method: :delete, data: { confirm: '削除してよろしいですか？' }, class: "btn btn-outline-danger btn-sm", id: "user_destroy" %></td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+  <br>
+</div>

--- a/app/views/admin/users/new.html.erb
+++ b/app/views/admin/users/new.html.erb
@@ -1,0 +1,25 @@
+<h1>ユーザ登録</h1>
+
+<% if @user.errors.any? %>
+  <div id="error_explanation">
+    <h2><%= pluralize(@user.errors.count, "error") %> prohibited this <%= @user.name %> from being saved:</h2>
+    <ul>
+    <% @user.errors.full_messages.each do |message| %>
+      <li><%= message %></li>
+    <% end %>
+    </ul>
+  </div>
+<% end %>
+<%= form_with(model: [:admin, @user], local: true) do |f| %>
+  <%= f.label :administrator %>
+  <%= f.check_box :administrator, {} , true, false %>
+  <%= f.label :name %>
+  <%= f.text_field :name %>
+  <%= f.label :email %>
+  <%= f.email_field :email %>
+  <%= f.label :password %>
+  <%= f.password_field :password %>
+  <%= f.label :password_confirmation %>
+  <%= f.password_field :password_confirmation %>
+  <%= f.submit "Create my account" %>
+<% end %>

--- a/app/views/admin/users/show.html.erb
+++ b/app/views/admin/users/show.html.erb
@@ -1,0 +1,2 @@
+<h1>Admin::Users#show</h1>
+<p>Find me in app/views/admin/users/show.html.erb</p>

--- a/app/views/admin/users/show.html.erb
+++ b/app/views/admin/users/show.html.erb
@@ -1,2 +1,34 @@
-<h1>Admin::Users#show</h1>
-<p>Find me in app/views/admin/users/show.html.erb</p>
+<h2><%= @user.name %>のページ</h2>
+<p>メールアドレス: <%= @user.email %></p>
+<table>
+  <tr>
+    <th>タスク名</th>
+    <th>詳細内容</th>
+    <th>登録日時</th>
+    <th><%= link_to "終了期限", tasks_path(sort_limit: "true") %></th>
+    <th>ステータス</th>
+    <th><%= link_to "優先順位", tasks_path(sort_priority: "true") %></th>
+    <th><%= link_to "登録者" %></th>
+  </tr>
+  <tbody>
+    <% @user.tasks.each do |t| %>
+      <tr>
+        <td><%= t.title %></td>
+        <td><%= t.content %></td>
+        <td><%= l t.created_at %></td>
+        <td><%= t.limit %></td>
+        <td><%= t.status %></td>
+        <td><%= t.priority %></td></div>
+        <td><%= t.user.name %></td></div>
+        <td><div class ='btn btn-light'><%= link_to "詳細を確認", task_path(t.id) %></div></td>
+        <td><div class ='btn btn-light'><%= link_to "編集", edit_task_path(t.id) %></div></td>
+        <td><div class ='btn btn-light'><%= link_to "削除", task_path(t.id), method: :delete, data: {confirm: "本当に削除しますか?"} %></div></td>
+      </tr>    
+    <% end %>
+  </tbody>
+</table>
+<%= link_to '編集', edit_admin_user_path(@user) %> 
+<% if current_user == @user && current_user.admin? %>
+  <%= link_to "管理者ページ", admin_users_path %>
+<% end %>
+<%= link_to 'Back', admin_users_path %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -20,12 +20,14 @@
     
     <div class="text-right">
       <% if logged_in? %>
-      <% link_to "UserList", admin_users_path if logged_in? %>
-        <%= link_to "Profile", user_path(current_user.id) %>
-        <%= link_to "Logout", session_path(current_user.id), method: :delete %>
-      <% else %>
-        <%= link_to "Sign up", new_user_path %>
-        <%= link_to "Login", new_session_path %>
+        <% if current_user.admin? %>
+          <%= link_to "UserList", admin_users_path %>
+        <% end %>
+          <%= link_to "Profile", user_path(current_user.id) %>
+          <%= link_to "Logout", session_path(current_user.id), method: :delete %>
+        <% else %>
+          <%= link_to "Sign up", new_user_path %>
+          <%= link_to "Login", new_session_path %>
       <% end %>
     </div>
     <%= yield %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -14,7 +14,17 @@
   </head>
 
   <body>
-    
+    <% flash.each do |key, value| %>
+      <%= content_tag(:div, value, class: "#{key}") %>
+    <% end %>
+
+    <% if logged_in? %>
+      <%= link_to "Profile", user_path(current_user.id) %>
+      <%= link_to "Logout", session_path(current_user.id), method: :delete %>
+    <% else %>
+      <%= link_to "Sign up", new_user_path %>
+      <%= link_to "Login", new_session_path %>
+    <% end %>
     <%= yield %>
   </body>
 </html>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -17,14 +17,17 @@
     <% flash.each do |key, value| %>
       <%= content_tag(:div, value, class: "#{key}") %>
     <% end %>
-
-    <% if logged_in? %>
-      <%= link_to "Profile", user_path(current_user.id) %>
-      <%= link_to "Logout", session_path(current_user.id), method: :delete %>
-    <% else %>
-      <%= link_to "Sign up", new_user_path %>
-      <%= link_to "Login", new_session_path %>
-    <% end %>
+    
+    <div class="text-right">
+      <% if logged_in? %>
+      <% link_to "UserList", admin_users_path if logged_in? %>
+        <%= link_to "Profile", user_path(current_user.id) %>
+        <%= link_to "Logout", session_path(current_user.id), method: :delete %>
+      <% else %>
+        <%= link_to "Sign up", new_user_path %>
+        <%= link_to "Login", new_session_path %>
+      <% end %>
+    </div>
     <%= yield %>
   </body>
 </html>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -14,6 +14,7 @@
   </head>
 
   <body>
+    
     <%= yield %>
   </body>
 </html>

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -1,0 +1,11 @@
+<h1>Log in</h1>
+<%= form_with(scope: :session, url: sessions_path, local: true) do |f| %>
+
+  <%= f.label :email %>
+  <%= f.email_field :email %>
+
+  <%= f.label :password %>
+  <%= f.password_field :password %>
+
+  <%= f.submit "Log in" %>
+<% end %>

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -11,6 +11,7 @@
     <th>ステータス</th>
     <th><%= link_to "優先順位", tasks_path(sort_priority: "true") %></th>
     <td><%= task.priorities.key(tasks.priority) if @task %></td>
+    <th>登録者</th>
     </tr>
   </thead>
 
@@ -22,6 +23,7 @@
         <td><%= task.limit %></td>
         <td><%= task.status %></td>
         <td><%= task.priority %></td>
+        <td><%= task.user.name %></td>
         <td><%= link_to 'Show', task_path(task), class: "btn btn-outline-primary" %></td>
         <td><%= link_to 'Edit', edit_task_path(task), class: "btn btn-outline-success" %></td>
         <td><%= link_to 'Destroy', task, method: :delete, data: { confirm: 'Are you sure?' }, class: "btn btn-outline-danger" %></td>

--- a/app/views/tasks/show.html.erb
+++ b/app/views/tasks/show.html.erb
@@ -1,4 +1,3 @@
-<p id="notice"><%= notice %></p>
 
 <p>
   <strong>タスク名</strong>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -1,0 +1,23 @@
+<%= form_with model: @user, local: true do |f| %>
+  <div class="field">
+    <%= f.label :name %>
+    <%= f.text_field :name, class: 'form-control mb-3' %>
+  </div>
+
+  <div class="field">
+    <%= f.label :email %>
+    <%= f.email_field :email, class: 'form-control mb-3' %>
+  </div>
+
+  <div class="field">
+    <%= f.label :password %>
+    <%= f.text_field :password %>
+  </div>
+
+  <div class="field">
+    <%= f.label :password_confirmation %>
+    <%= f.text_field :password_confirmation %>
+  </div>
+
+  <%= f.submit "更新", class: "btn btn-primary"%>
+<%end%>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -1,0 +1,23 @@
+<h1>Sign up</h1>
+
+<% if @user.errors.any? %>
+  <div id="error_explanation">
+    <h2><%= pluralize(@user.errors.count, "error") %> prohibited this <%= @user.name %> from being saved:</h2>
+    <ul>
+    <% @user.errors.full_messages.each do |message| %>
+      <li><%= message %></li>
+    <% end %>
+    </ul>
+  </div>
+<% end %>
+<%= form_with(model: @user, local: true) do |f| %>
+  <%= f.label :name %>
+  <%= f.text_field :name %>
+  <%= f.label :email %>
+  <%= f.email_field :email %>
+  <%= f.label :password %>
+  <%= f.password_field :password %>
+  <%= f.label :password_confirmation %>
+  <%= f.password_field :password_confirmation %>
+  <%= f.submit "Create my account" %>
+<% end %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,0 +1,10 @@
+<h1><%= @user.name %>のページ</h1>
+
+<p>メールアドレス: <%= @user.email %></p>
+
+<p>
+<% if @user == current_user %>
+  <%= link_to "プロフィールの編集", edit_user_path%>
+<% end %>
+</p><%= link_to '戻る', tasks_path, class: 'btn btn-outline-success mt-3' %>
+</p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,7 @@
 Rails.application.routes.draw do
+  namespace :admin do
+    resources :users
+  end
   root to: 'tasks#index'
   resources :tasks do
     collection do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,4 +8,5 @@ Rails.application.routes.draw do
       get 'search'
     end
   end
+  resources :sessions, only: [:new, :create, :destroy]
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,6 @@
 Rails.application.routes.draw do
+  get 'users/new'
+  resources :users
   namespace :admin do
     resources :users
   end
@@ -9,4 +11,5 @@ Rails.application.routes.draw do
     end
   end
   resources :sessions, only: [:new, :create, :destroy]
+
 end

--- a/db/migrate/20230310014157_create_users.rb
+++ b/db/migrate/20230310014157_create_users.rb
@@ -1,0 +1,11 @@
+class CreateUsers < ActiveRecord::Migration[6.1]
+  def change
+    create_table :users do |t|
+      t.string :name, null: false
+      t.text :email, uniqueness: true, null: false
+      t.string :password_digest, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20230310020528_add_admin_to_users.rb
+++ b/db/migrate/20230310020528_add_admin_to_users.rb
@@ -1,0 +1,5 @@
+class AddAdminToUsers < ActiveRecord::Migration[6.1]
+  def change
+    add_column :users, :admin, :boolean, default: false, null: false
+  end
+end

--- a/db/migrate/20230310044013_add_user_id_to_tasks.rb
+++ b/db/migrate/20230310044013_add_user_id_to_tasks.rb
@@ -1,0 +1,10 @@
+class AddUserIdToTasks < ActiveRecord::Migration[6.1]
+  def up
+    execute 'DELETE FROM tasks;'
+    add_reference :tasks, :user, null: false, index: true
+  end
+
+  def down
+    remove_reference :tasks, :user, index: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_03_10_014157) do
+ActiveRecord::Schema.define(version: 2023_03_10_020528) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -31,6 +31,7 @@ ActiveRecord::Schema.define(version: 2023_03_10_014157) do
     t.string "password_digest", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.boolean "admin", default: false, null: false
   end
 
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_03_10_020528) do
+ActiveRecord::Schema.define(version: 2023_03_10_044013) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -23,6 +23,8 @@ ActiveRecord::Schema.define(version: 2023_03_10_020528) do
     t.date "limit"
     t.string "status"
     t.string "priority"
+    t.bigint "user_id", null: false
+    t.index ["user_id"], name: "index_tasks_on_user_id"
   end
 
   create_table "users", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_03_07_152437) do
+ActiveRecord::Schema.define(version: 2023_03_10_014157) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -23,6 +23,14 @@ ActiveRecord::Schema.define(version: 2023_03_07_152437) do
     t.date "limit"
     t.string "status"
     t.string "priority"
+  end
+
+  create_table "users", force: :cascade do |t|
+    t.string "name", null: false
+    t.text "email", null: false
+    t.string "password_digest", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,3 +5,12 @@
 #
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
+10.times do |n|
+  email = Faker::Internet.email
+  name = "name"
+  password = "password"
+  User.create!(name: name,
+               email: email,
+               password_digest: password,
+               )
+end

--- a/spec/factories/tasks.rb
+++ b/spec/factories/tasks.rb
@@ -2,7 +2,7 @@ FactoryBot.define do
   factory :task do
     title { 'test_title' }
     content { 'test_content' }
-    limit { '2023-03-10' }
+    limit { '2023-03-11' }
     status { '着手中' }
   end
 

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :user do
+    name { "MyString" }
+    email { "MyText" }
+    password_digest { "MyString" }
+  end
+end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -2,14 +2,14 @@ FactoryBot.define do
   factory :user do
     name { "一般ユーザ" }
     email { "ippan@gmail.com" }
-    password_digest { "12345678" }
+    password { "12345678" }
     admin { "false" }
   end
 
   factory :second_user, class: User do
     name { "管理者ユーザ" }
     email { "kanrisya@gmail.com" }
-    password_digest { "87654321" }
+    password { "87654321" }
     admin { "true" }
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,7 +1,15 @@
 FactoryBot.define do
   factory :user do
-    name { "MyString" }
-    email { "MyText" }
-    password_digest { "MyString" }
+    name { "一般ユーザ" }
+    email { "ippan@gmail.com" }
+    password_digest { "12345678" }
+    admin { "false" }
+  end
+
+  factory :second_user, class: User do
+    name { "管理者ユーザ" }
+    email { "kanrisya@gmail.com" }
+    password_digest { "87654321" }
+    admin { "true" }
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe User, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/system/task_speck.rb
+++ b/spec/system/task_speck.rb
@@ -1,8 +1,16 @@
 require 'rails_helper'
 RSpec.describe 'タスク管理機能', type: :system do
+  let!(:user) { FactoryBot.create(:user) }
+  let!(:task) { FactoryBot.create(:task, user: user) }
+  let!(:second_task) { FactoryBot.create(:second_task, user: user) }
+
   describe '新規作成機能' do
     context 'タスクを新規作成した場合' do
       it '作成したタスクが表示される' do
+        visit new_session_path
+        fill_in 'session[email]', with: 'ippan@gmail.com'
+        fill_in 'session[password]', with: '12345678'
+        click_button 'Log in'
         visit new_task_path
         fill_in 'タスク名', with: 'test title'
         fill_in 'コメント', with: 'test description'
@@ -16,23 +24,29 @@ RSpec.describe 'タスク管理機能', type: :system do
       end
     end
   end
+
   describe '一覧表示機能' do
     context '一覧画面に遷移した場合' do
       it '作成済みのタスク一覧が表示される' do
-        task = FactoryBot.create(:task, title: 'task')
+        visit new_session_path
+        fill_in 'session[email]', with: 'ippan@gmail.com'
+        fill_in 'session[password]', with: '12345678'
+        click_button 'Log in'
         visit tasks_path
-        expect(page).to have_content 'task'
+        expect(page).to have_content 'test'
       end
     end
 
     context 'タスクが作成日時の降順に並んでいる場合' do
       it '新しいタスクが一番上に表示される' do
-        task1 = FactoryBot.create(:task, title: 'task1', content: 'content1', created_at: Time.zone.now)
-        task2 = FactoryBot.create(:task, title: 'task2', content: 'content2', created_at: Time.zone.now - 1.day)
+        visit new_session_path
+        fill_in 'session[email]', with: 'ippan@gmail.com'
+        fill_in 'session[password]', with: '12345678'
+        click_button 'Log in'
         visit tasks_path
         task_list = all('.task_list') 
-        expect(task_list[0]).to have_content 'task1'
-        expect(task_list[1]).to have_content 'task2'
+        expect(task_list[0]).to have_content 'テスト2'
+        expect(task_list[1]).to have_content 'test_title'
       end
     end
   end
@@ -40,10 +54,13 @@ RSpec.describe 'タスク管理機能', type: :system do
   describe '詳細表示機能' do
     context '任意のタスク詳細画面に遷移した場合' do
       it '該当タスクの内容が表示される' do
-        task = FactoryBot.create(:task, title: 'task', content: 'content')
+        visit new_session_path
+        fill_in 'session[email]', with: 'ippan@gmail.com'
+        fill_in 'session[password]', with: '12345678'
+        click_button 'Log in'
         visit task_path(task)
-        expect(page).to have_content 'task'
-        expect(page).to have_content 'content'
+        expect(page).to have_content 'test_title'
+        expect(page).to have_content 'test_content'
       end
     end
   end
@@ -51,14 +68,16 @@ RSpec.describe 'タスク管理機能', type: :system do
   describe '終了期限ソート機能' do
     context 'タスクが終了期限の降順に並んでいる場合' do
       it '期限が先のタスクが一番上に表示される' do
-        task1 = FactoryBot.create(:task, title: 'task1', content: 'content1', limit: Time.current + 5.days)
-        task2 = FactoryBot.create(:task, title: 'task2', content: 'content2', limit: Time.current + 10.days)
+        visit new_session_path
+        fill_in 'session[email]', with: 'ippan@gmail.com'
+        fill_in 'session[password]', with: '12345678'
+        click_button 'Log in'
         visit tasks_path
         click_on '終了期限'
         sleep(0.5)
         task_list = all('.task_list') 
-        expect(task_list[0]).to have_content 'task2'
-        expect(task_list[1]).to have_content 'task1'
+        expect(task_list[0]).to have_content 'test_title'
+        expect(task_list[1]).to have_content 'テスト2'
       end
     end
   end
@@ -66,23 +85,25 @@ RSpec.describe 'タスク管理機能', type: :system do
   describe '検索機能' do
     describe 'タイトルで検索する場合' do
       it '検索結果に該当するタスクが表示される' do
-      task1 = FactoryBot.create(:task, title: 'task1', status: '未着手')
-      task2 = FactoryBot.create(:task, title: 'task2', status: '着手中')
-      task3 = FactoryBot.create(:task, title: 'task3', status: '完了')
+      visit new_session_path
+      fill_in 'session[email]', with: 'ippan@gmail.com'
+      fill_in 'session[password]', with: '12345678'
+      click_button 'Log in'
       visit tasks_path
-      fill_in 'keyword', with: 'task1'
+      fill_in 'keyword', with: 'test'
       click_on '検索'
       sleep(0.5)
       
-      expect(page).to have_content 'task1'
+      expect(page).to have_content 'test_title'
       end
     end
 
     describe 'ステータスで検索する場合' do
       before do
-        task1 = FactoryBot.create(:task, title: 'task1', status: '未着手')
-        task2 = FactoryBot.create(:task, title: 'task2', status: '着手中')
-        task3 = FactoryBot.create(:task, title: 'task3', status: '完了')
+        visit new_session_path
+        fill_in 'session[email]', with: 'ippan@gmail.com'
+        fill_in 'session[password]', with: '12345678'
+        click_button 'Log in'
         visit tasks_path
         select '着手中', from: 'status'
         click_on '検索'
@@ -90,24 +111,25 @@ RSpec.describe 'タスク管理機能', type: :system do
       end
   
       it '検索結果に該当するタスクが表示される' do
-        expect(page).to have_content 'task2'
+        expect(page).to have_content 'test_title'
       end
     end
   
     describe 'タイトルとステータスで検索する場合' do
       before do
-        task1 = FactoryBot.create(:task, title: 'task1', status: '未着手')
-        task2 = FactoryBot.create(:task, title: 'task2', status: '着手中')
-        task3 = FactoryBot.create(:task, title: 'task3', status: '完了')
+        visit new_session_path
+        fill_in 'session[email]', with: 'ippan@gmail.com'
+        fill_in 'session[password]', with: '12345678'
+        click_button 'Log in'
         visit tasks_path
-        fill_in 'keyword', with: 'task1'
-        select '未着手', from: 'status'
+        fill_in 'keyword', with: 'test'
+        select '着手中', from: 'status'
         click_on '検索'
         sleep(0.5)
       end
   
       it '検索結果に該当するタスクが表示される' do
-        expect(page).to have_content 'task1'
+        expect(page).to have_content 'test_title'
       end
     end
   end

--- a/spec/system/user_speck.rb
+++ b/spec/system/user_speck.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+RSpec.describe 'ユーザ機能', type: :system do
+  describe 'ユーザ登録のテスト' do
+    context 'ユーザを新規作成した場合' do
+      it 'ユーザの新規登録がされる' do
+        visit new_user_path
+        fill_in 'user[name]', with: 'test'
+        fill_in 'user[email]', with: 'test@example.com'
+        fill_in 'user[password]', with: 'password'
+        fill_in 'user[password_confirmation]', with: 'password'
+        click_button 'Create my account'
+        expect(page).to have_content 'test'
+      end
+
+      it 'ログインしていない場合、タスク一覧画面にアクセスできない' do
+        visit tasks_path
+        expect(page).to have_content 'Log in'
+      end
+    end
+  end
+end

--- a/spec/system/user_speck.rb
+++ b/spec/system/user_speck.rb
@@ -1,20 +1,161 @@
 require 'rails_helper'
 RSpec.describe 'ユーザ機能', type: :system do
+  let!(:user){FactoryBot.create(:user)}
+  let!(:second_user){FactoryBot.create(:second_user)}
+
   describe 'ユーザ登録のテスト' do
     context 'ユーザを新規作成した場合' do
       it 'ユーザの新規登録がされる' do
         visit new_user_path
-        fill_in 'user[name]', with: 'test'
-        fill_in 'user[email]', with: 'test@example.com'
-        fill_in 'user[password]', with: 'password'
-        fill_in 'user[password_confirmation]', with: 'password'
+        fill_in 'user[name]', with: '一般ユーザ'
+        fill_in 'user[email]', with: 'ippan@gmail.com'
+        fill_in 'user[password]', with: '12345678'
+        fill_in 'user[password_confirmation]', with: '12345678'
         click_button 'Create my account'
-        expect(page).to have_content 'test'
+        expect(page).to have_content '一般ユーザ'
       end
 
       it 'ログインしていない場合、タスク一覧画面にアクセスできない' do
         visit tasks_path
         expect(page).to have_content 'Log in'
+      end
+    end
+  end
+
+  describe 'セッション機能のテスト' do
+    context 'ログインした場合' do
+      it '自分のタスク一覧が表示される' do
+        visit new_session_path
+        fill_in 'session[email]', with: 'ippan@gmail.com'
+        fill_in 'session[password]', with: '12345678'
+        click_button 'Log in'
+        expect(page).to have_content 'Tasks'
+      end
+    end
+
+    context 'ログインした場合' do
+      it '自分の詳細画面(マイページ)に飛べる' do
+        visit new_session_path
+        fill_in 'session[email]', with: 'ippan@gmail.com'
+        fill_in 'session[password]', with: '12345678'
+        click_button 'Log in'
+        click_link 'Profile'
+        expect(page).to have_content '一般ユーザのページ'
+      end
+    end
+
+    context '一般ユーザが他人の詳細画面に飛ぶ場合' do
+      it 'タスク一覧画面に遷移する' do
+        visit new_session_path
+        fill_in 'session[email]', with: 'ippan@gmail.com'
+        fill_in 'session[password]', with: '12345678'
+        click_button 'Log in'
+        visit user_path(second_user)
+        visit tasks_path
+        expect(page).to have_content 'Tasks'
+      end
+    end
+
+    context 'ログアウト' do
+      it 'タスク一覧画面に遷移する' do
+        visit new_session_path
+        fill_in 'session[email]', with: 'ippan@gmail.com'
+        fill_in 'session[password]', with: '12345678'
+        click_button 'Log in'
+        click_link 'Logout'
+        expect(page).to have_content 'Login'
+      end
+    end
+  end
+
+  describe '管理者機能のテスト' do
+    context '管理ユーザが管理画面にアクセスする場合' do
+      it 'アクセスできる' do
+        visit new_session_path
+        fill_in 'session[email]', with: 'kanrisya@gmail.com'
+        fill_in 'session[password]', with: '87654321'
+        click_on "Log in"
+        visit tasks_path
+        click_link 'UserList'
+        expect(page).to have_content 'ユーザー管理画面'
+      end
+    end
+
+    context '一般ユーザが管理画面にアクセスする場合' do
+      it 'アクセスできない' do
+        visit new_session_path
+        fill_in 'session[email]', with: 'ippan@gmail.com'
+        fill_in 'session[password]', with: '12345678'
+        click_on "Log in"
+        visit admin_users_path
+        expect(page).to have_content '管理者以外はアクセスできません'
+      end
+    end
+
+    context '管理ユーザがユーザの新規登録を行う場合' do
+      it '登録できる' do
+        visit new_session_path
+        fill_in 'session[email]', with: 'kanrisya@gmail.com'
+        fill_in 'session[password]', with: '87654321'
+        click_on "Log in"
+        visit tasks_path
+        click_link 'UserList'
+        click_link 'ユーザーを登録する'
+        visit new_admin_user_path
+        fill_in 'user[name]', with: 'test'
+        fill_in 'user[email]', with: 'test@gmail.com'
+        fill_in 'user[password]', with: '12345678'
+        fill_in 'user[password_confirmation]', with: '12345678'
+        click_on "Create my account"
+        expect(page).to have_content 'ユーザー登録が完了しました'
+      end
+    end
+
+    context '管理ユーザがユーザの詳細画面にアクセスする場合' do
+      it 'アクセスできる' do
+        visit new_session_path
+        fill_in 'session[email]', with: 'kanrisya@gmail.com'
+        fill_in 'session[password]', with: '87654321'
+        click_on "Log in"
+        visit tasks_path
+        click_link 'UserList'
+        visit admin_user_path(user)
+        expect(page).to have_content "一般ユーザ"
+      end
+    end
+
+    context '管理ユーザがユーザの編集画面にアクセスする場合' do
+      it 'ユーザを編集できる' do
+        visit new_session_path
+        fill_in 'session[email]', with: 'kanrisya@gmail.com'
+        fill_in 'session[password]', with: '87654321'
+        click_on "Log in"
+        visit tasks_path
+        click_link 'UserList'
+        visit edit_admin_user_path(user)
+        fill_in 'user[name]', with: 'test'
+        fill_in 'user[email]', with: 'test@gmail.com'
+        fill_in 'user[password]', with: '12345678'
+        fill_in 'user[password_confirmation]', with: '12345678'
+        click_on "Update"
+        expect(page).to have_content "ユーザー情報を更新しました"
+      end
+    end
+
+    context '管理ユーザがユーザの削除をする場合' do
+      it 'ユーザを削除できる' do
+        visit new_session_path
+        fill_in 'session[email]', with: 'kanrisya@gmail.com'
+        fill_in 'session[password]', with: '87654321'
+        click_on "Log in"
+        visit tasks_path
+        click_link 'UserList'
+        visit admin_users_path
+        # page.all('削除')[1]
+        accept_confirm do
+          click_link '削除', match: :first
+        end
+        expect(page).to have_content "削除しました"
       end
     end
   end


### PR DESCRIPTION
ユーザモデルを作成する
最初のユーザをseedで作成する
ユーザとタスクを紐づける
タスク一覧画面とマイページに表示されているすべてのタスクに、作成したユーザ名を表示させること
ユーザのemailにユニーク制約をつける
関連（アソシエーションで使用するid）に対してインデックスをつける
bcrypt-ruby以外は、Gemを使わずに実装する
ログイン機能を実装する
ログインをせずにタスク一覧のページに飛ぼうとしたときは、ログインページに遷移させる
自分が作成したタスクだけを表示させる
ログアウト機能を実装する
ユーザの新規登録画面、ログイン画面、詳細・マイページ（show）画面を作成する
ユーザを新規登録（create）をしたとき、同時にログインもさせる
ログインしているときは、ユーザの新規登録画面（new画面）に行かせないようにコントローラで制御する
自分（current_user）以外のユーザのマイページ（userのshow画面）にアクセスしたらタスク一覧に遷移させる
管理画面を追加する
管理画面にはかならず /admin というURLを先頭につける
管理画面でユーザ一覧表示・作成・更新・削除ができる（管理画面のビューは、パーシャル化しなくても構わない）
ユーザを削除したら、そのユーザに紐づいているタスクを全て削除する
ユーザの一覧画面で、そのユーザに紐づいているタスクの数を表示する
N+1問題を回避するための仕組みを取り入れること
ユーザが作成したタスクの一覧を、そのユーザのマイページ（userのshow画面）で見られる
ユーザを管理ユーザと一般ユーザで区別する
管理ユーザだけがユーザ管理画面にアクセスできる
一般ユーザが管理画面にアクセスしたとき、tasks/indexに飛ばして「管理者以外はアクセスできない」旨のflashメッセージを出力する
ユーザ管理画面でロール（管理者権限）の付与と削除ができる
管理ユーザが一人もいなくなってしまわないように、モデルのコールバックを利用して更新・削除の制御をする
テスト項目を満たすようSystem Specを書く
ユーザ登録のテスト
ユーザの新規登録ができること
ユーザがログインせずタスク一覧画面に飛ぼうとしたとき、ログイン画面に遷移すること
セッション機能のテスト
ログインができること
自分の詳細画面(マイページ)に飛べること
一般ユーザが他人の詳細画面に飛ぶとタスク一覧画面に遷移すること
ログアウトができること
管理画面のテスト
管理ユーザは管理画面にアクセスできること
一般ユーザは管理画面にアクセスできないこと
管理ユーザはユーザの新規登録ができること
管理ユーザはユーザの詳細画面にアクセスできること
管理ユーザはユーザの編集画面からユーザを編集できること
管理ユーザはユーザの削除をできること
ブランチのstep4をherokuにデプロイし、herokuのURLを提出すること
Herokuにデプロイした際に、すでに登録されているタスクとユーザが紐づいているようにすること